### PR TITLE
Remove ClientOnly component, which is not compatible with React 18

### DIFF
--- a/deploy/docker-compose/todo-remix.yaml
+++ b/deploy/docker-compose/todo-remix.yaml
@@ -3,6 +3,7 @@ services:
     build: ../../examples/express
     environment:
       - HANKO_API_URL=http://hanko:8000
+      - REMIX_APP_HANKO_API=http://localhost:8000
     networks:
       - intranet
 

--- a/examples/remix/app/lib/hanko.client.ts
+++ b/examples/remix/app/lib/hanko.client.ts
@@ -1,6 +1,6 @@
 // `.client.ts` files are only supposed to run on the client. I could not find this
 // documented on the remix docs but someone on the remix discord told me this is how it is
 // supposed to work.
-import { register } from '@teamhanko/hanko-elements';
+import { register } from '@teamhanko/hanko-elements/hanko-auth';
 
 export { register as registerHankoAuth };

--- a/examples/remix/app/root.tsx
+++ b/examples/remix/app/root.tsx
@@ -47,13 +47,6 @@ export default function App() {
       <Outlet />
       <ScrollRestoration />
       <Scripts />
-      {/* Add the URL of the Hanko API instance to the window object so that
-        it can be accessed in `useEffect` etc */}
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `window.ENV = ${JSON.stringify(ENV)}`,
-        }}
-      />
       <LiveReload />
     </>
   );

--- a/examples/remix/app/routes/index.tsx
+++ b/examples/remix/app/routes/index.tsx
@@ -1,15 +1,22 @@
-import { useEffect } from "react";
-import { ClientOnly } from "remix-utils";
+import { useEffect, Suspense } from "react";
 import { registerHankoAuth } from "~/lib/hanko.client";
 import { Hanko } from "@teamhanko/hanko-frontend-sdk";
 import styles from "~/styles/todo.css";
 import type { ActionArgs, LinksFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
-import { useFetcher } from "@remix-run/react";
+import {json, redirect} from "@remix-run/node";
+import {useFetcher, useLoaderData} from "@remix-run/react";
 
 export const links: LinksFunction = () => {
   return [{ rel: "stylesheet", href: styles }];
 };
+
+export const loader = async () => {
+  return json({
+    ENV: {
+      HANKO_URL: process.env.REMIX_APP_HANKO_API
+    },
+  });
+}
 
 export const action = async ({ request }: ActionArgs) => {
   const formData = await request.formData();
@@ -33,12 +40,12 @@ export default function Index() {
     return () => document.removeEventListener("hankoAuthSuccess", handler);
   });
 
+  const data = useLoaderData();
   return (
     <div className="content">
-      {/* Ensures that the component is only rendered on the frontend */}
-      <ClientOnly fallback={"Loading..."}>
-        {() => <hanko-auth lang="en" api={window.ENV.HANKO_URL} />}
-      </ClientOnly>
+      <Suspense fallback={"Loading..."}>
+        <hanko-auth lang="en" api={data.ENV.HANKO_URL} />
+      </Suspense>
     </div>
   );
 }

--- a/examples/remix/package-lock.json
+++ b/examples/remix/package-lock.json
@@ -11336,9 +11336,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -18682,9 +18682,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.19.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz",
-      "integrity": "sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.6.tgz",
+      "integrity": "sha512-oyu0m54SGCtzh6EClBVqDDlAYRz4jrVtKwQ7ZnsEmMI9HnzuZFj8QFwAY1M5uniIYACdGvv0PBWPF2kO0aNofA==",
       "peer": true
     },
     "zwitch": {


### PR DESCRIPTION
Hi @IgnisDa! I found one other issue, which is that the ClientOnly component is not compatible with React 18. Here is a fix, plus a fix for some changed conventions resulting from you reverting the client libraries.